### PR TITLE
fix: `tx_out` table migration

### DIFF
--- a/schema/migration-2-0044-20240912.sql
+++ b/schema/migration-2-0044-20240912.sql
@@ -8,7 +8,7 @@ BEGIN
   IF next_version = 44 THEN
     -- EXECUTE 'ALTER TABLE "reward" ADD COLUMN "id" INT8 NOT NULL' ;
     -- EXECUTE 'ALTER TABLE "reward_rest" ADD COLUMN "id" INT8 NOT NULL' ;
-    EXECUTE 'ALTER TABLE "tx_out" ADD COLUMN "consumed_by_tx_id" INT8 NULL' ;
+    EXECUTE 'ALTER TABLE "tx_out" ADD COLUMN IF NOT EXISTS "consumed_by_tx_id" INT8 NULL' ;
     -- Hand written SQL statements can be added here.
     UPDATE schema_version SET stage_two = next_version ;
     RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;


### PR DESCRIPTION
# Description

There is an issue with your migration of the `tx_out` table which leads to failure upon migration from version `13.5.0.2` to `13.6.0.2`.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [x] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [x] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
